### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "~5.2.2"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed at node 14 or older. So this adapter requires node 16 or newer.